### PR TITLE
Fix password change url for 1.9

### DIFF
--- a/users/forms.py
+++ b/users/forms.py
@@ -8,7 +8,6 @@ from distutils.version import LooseVersion
 from .models import User
 
 
-import pdb; pdb.set_trace()
 PASSWD_URL = "password/"
 if LooseVersion(django.get_version()) >= LooseVersion("1.9"):
     PASSWD_URL = "../" + PASSWD_URL

--- a/users/forms.py
+++ b/users/forms.py
@@ -1,10 +1,17 @@
 # -*- coding: utf-8 -*-
+import django
 from django import forms
 from django.contrib.auth.forms import ReadOnlyPasswordHashField
 from django.utils.translation import ugettext_lazy as _
 
+from distutils.version import LooseVersion
 from .models import User
 
+
+import pdb; pdb.set_trace()
+PASSWD_URL = "password/"
+if LooseVersion(django.get_version()) >= LooseVersion("1.9"):
+    PASSWD_URL = "../" + PASSWD_URL
 
 class UserCreationForm(forms.ModelForm):
     """
@@ -71,7 +78,7 @@ class UserChangeForm(forms.ModelForm):
     password = ReadOnlyPasswordHashField(label=_("Password"),
         help_text=_("Raw passwords are not stored, so there is no way to see "
                     "this user's password, but you can change the password "
-                    "using <a href=\"password/\">this form</a>."))
+                    "using <a href=\"{}\">this form</a>.".format(PASSWD_URL)))
 
     class Meta:
         model = User

--- a/users/forms.py
+++ b/users/forms.py
@@ -12,6 +12,7 @@ PASSWD_URL = "password/"
 if LooseVersion(django.get_version()) >= LooseVersion("1.9"):
     PASSWD_URL = "../" + PASSWD_URL
 
+
 class UserCreationForm(forms.ModelForm):
     """
     A form that creates a user, with no privileges, from the given username and


### PR DESCRIPTION
The admin password change url for users [changed in django 1.9](https://docs.djangoproject.com/en/1.9/releases/1.9/#minor-features). This patch provides the corrected link for 1.9 upward.